### PR TITLE
Add expiry info to env along with token

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const os = core.getInput('os');
 
 let commandStr = []
 if(command.toLowerCase() === 'build') {
-  commandStr.push("aio app deploy --skip-deploy")
+  commandStr.push("aio app build")
 }
 else if(command.toLowerCase() === 'deploy') {
   let deployCmd = 'aio app deploy  --skip-build'

--- a/index.js
+++ b/index.js
@@ -93,9 +93,11 @@ function generateAuthToken() {
   .then(res => {
     console.log('Generated auth token successfully')
     //set token to be used by CLI
-    core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN', res)
+    core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_TOKEN', res)
     //mask the env var for logging
-    core.setSecret('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN')
+    core.setSecret('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_TOKEN')
+    const expiry = Date.now() + 30 * 60 * 1000 //30 mins from current time
+    core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
     core.setFailed(e.message)


### PR DESCRIPTION
Fixes #10 
Add expiry info to env along with token.
Wrap token and expiry in token object accessible via aio config.
TODO - This change also requires change in aio-lib-ims to read expiry set from environment as  Number and not string.
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
