### PR TITLE
fix typo and replace abobe by above

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This Github action supports following commands
 3) `deploy`
     * Standalone App
       1) AIO_RUNTIME_NAMESPACE - namespace to be used for the App
-      2) AIO_RUNTIME_AUTH - auth for abobe namespace
+      2) AIO_RUNTIME_AUTH - auth for above namespace
     * [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/)
       1) AIO_RUNTIME_NAMESPACE - namespace to be used for the App
-      2) AIO_RUNTIME_AUTH - auth for abobe namespace
+      2) AIO_RUNTIME_AUTH - auth for above namespace
       3) AIO_PROJECT_ID - Adobe I/O Console project ID
       4) AIO_PROJECT_NAME - Adobe I/O Console project name
       5) AIO_PROJECT_ORG_ID - IMS Org id


### PR DESCRIPTION
Small fix for README.md.

## Description

There was a typo in the README.md file. I've replaced "abobe" by "above".

## Related Issue

No related issue, just found a typo while reading public README.md file

## Motivation and Context

It improves readability only :)

## How Has This Been Tested?

Nothing to test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change (non-breaking change which improves documentation)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
