### PR TITLE
[DRAFT] add working directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ jobs:
           noPublish: false
 ```
 
+## Running from a sub-directory
+
+If the aio project is not in the root directory of your repository, you can specify the working directory by passing `workin-directory` as a string to the `with` parameter in your workflow yaml file. Example:
+
+```
+- name: Build
+  env:
+    AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
+  uses: adobe/aio-apps-action@2.0.1
+  with:
+    working-directory: './some-sub-dir'
+    os: ${{ matrix.os }}
+    command: build
+```
+
  ## Contributing
 
 Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING.md) for more information.

--- a/index.js
+++ b/index.js
@@ -41,9 +41,11 @@ else if(command.toLowerCase() === 'auth') {
   generateAuthToken()
 }
 
+const workingDirectory = core.getInput('working-directory') || '.'
+
 try {
   console.log(`Executing command ${command}!`)
-  runCLICommand(os, commandStr)
+  runCLICommand(os, commandStr, workingDirectory)
   .then(() => {
     console.log("action completed")
   })
@@ -54,13 +56,13 @@ try {
   core.setFailed(error.message);
 }
 
-async function runCLICommand(os, commandStr) {
+async function runCLICommand(os, commandStr, cwd) {
   let cmd
   for(let i = 0; i < commandStr.length; i++) {
     cmd = commandStr[i]
     if(os && os.startsWith("ubuntu"))
       cmd = 'sudo --preserve-env ' + cmd
-      await exec.exec(cmd)
+      await exec.exec(cmd, [], { cwd })
   }
 }
 


### PR DESCRIPTION
Allows setting the working directory from workflow yaml files.

## Description

With this change, the working directory can be set in a workflow step like:

```yaml
    steps:
      - name: Build
        env:
          AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
        uses: adobe/aio-apps-action@2.0.2
        with:
         working-directory: './tools'
          os: ${{ matrix.os }}
          command: build
```

This is useful for projects that are not primarily aio apps, so would prefer to have aio files in a sub-directory, but still want to benefit from github actions, eg: https://github.com/hlxsites/maidenform/pull/171#issuecomment-1476484017

## How Has This Been Tested?

In progress, will move from draft to open PR once completed. See https://github.com/adobe/aio-apps-action/issues/28.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
