### PR TITLE
feat: add default scopes, make scope configuration optional (jwt only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This Github action supports following commands
       2) AIO_RUNTIME_AUTH - auth for above namespace
       3) AIO_PROJECT_ID - Adobe I/O Console project ID
       4) AIO_PROJECT_NAME - Adobe I/O Console project name
-      5) AIO_PROJECT_ORG_ID - IMS Org id
+      5) AIO_PROJECT_ORG_ID - AMS Org id (e.g. '53444')
       6) AIO_PROJECT_WORKSPACE_ID - Workspace Id
       7) AIO_PROJECT_WORKSPACE_NAME - Workspace name
       8) AIO_PROJECT_WORKSPACE_DETAILS_SERVICES - list of services added to above workspace in following format (ex. '[{"code": "AdobeIOManagementAPISDK", "name": "I/O Management API"}]' )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ This Github action supports following commands
 1) [build](https://github.com/adobe/aio-cli-plugin-app#aio-appbuild) - Builds App Builder application. This is similar to using `aio app build` command using AIO CLI
 2) [test](https://github.com/adobe/aio-cli-plugin-app#aio-apptest) - Test App Builder application. This is similar to using `aio app test` command using AIO CLI
 3) [deploy](https://github.com/adobe/aio-cli-plugin-app#aio-appdeploy) - Deploys App Builder application. This is similar to running `aio app deploy  --skip-build` command using AIO CLI. Deploy Command also supports `--no-publish` flag for `aio app deploy` command to control publishing of Extensions. See usage section for more details.
-4) `auth` - (Deprecated)Generates JWT based IMS Token and adds that to Github Action Environment for AIO CLI to use. The token is required to build and deploy App Builder [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/).
+4) `auth` - (Deprecated) Generates JWT based IMS Token and adds that to Github Action Environment for AIO CLI to use. The token is required to build and deploy App Builder [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/).
+    * JWT credential used in this step must have scopes attached that allow interaction with the Extension Registry API and Developer Console API. This can be achieved by adding the **I/O Management API** to the credential in the Developer Console. The appropriate scopes will then be automatically requested and attached to the token generated during this step.
+    - (Optional) If the credential already has scopes attached that allow access to the Extension Registry API and Developer Console API, see the optional **auth** step below for how to configure the custom **SCOPES** variable to request a specific set of scopes.
+ 
 5) `oauth_sts` - Generates OAuth Server-To-Server based IMS Token and adds that to Github Action Environment for AIO CLI to use. The token is required to build and deploy App Builder [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/).
 
 ## Prerequisites for Commands
@@ -44,9 +47,9 @@ This Github action supports following commands
       2) CLIENTSECRET - Client secret for the Adobe I/O console project
       3) TECHNICALACCOUNTID - Technical account Id for the Adobe I/O console project
       4) IMSORGID - IMS Org Id
-      5) SCOPES - Bracket-enclosed, double-quoted, and comma-separated list of required meta scopes for JWT token
+      5) KEY - Private key associated with project
+      6) (optional) SCOPES - List of meta scopes to request for JWT token
           - Example: `["meta_scope1", "meta_scope2"]`
-      6) KEY - Private key associated with project
 5) `oauth_sts`
       1) CLIENTID - Client id of Adobe I/O console project
       2) CLIENTSECRET - Comma separated String of Client secrets of Adobe I/O console project

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Github action supports following commands
 2) [test](https://github.com/adobe/aio-cli-plugin-app#aio-apptest) - Test App Builder application. This is similar to using `aio app test` command using AIO CLI
 3) [deploy](https://github.com/adobe/aio-cli-plugin-app#aio-appdeploy) - Deploys App Builder application. This is similar to running `aio app deploy  --skip-build` command using AIO CLI. Deploy Command also supports `--no-publish` flag for `aio app deploy` command to control publishing of Extensions. See usage section for more details.
 4) `auth` - Generates IMS Token and adds that to Github Action Environment for AIO CLI to use. The token is required to build and deploy App Builder [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/).
+    * Note: Credential must have the **I/O Management API** added. This can be done either via the Developer Console or with the `aio` CLI using `aio app add service`
 
 ## Prerequisites for Commands
 
@@ -162,18 +163,6 @@ jobs:
           command: deploy
           noPublish: false
 ```
-
-#### Required scopes
-
-To deploy an extension, the credential used with this action must have access to the following scopes: 
-
-- `AdobeID, openid, read_organizations, additional_info.projectedProductContext, additional_info.roles, adobeio_api, read_client_secret, manage_client_secrets`
-
-The easiest way to attach these scopes to your credential is by subscribing the credential to the **I/O Management API** in the Developer Console.
-
-The only way to ensure these scopes are requested during token generation is to add the `ent_adobeio_sdk` super-scope to the **SCOPES** environment variable specified above: 
-
-- `["ent_adobeio_sdk"]`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ To deploy an extension, the credential used with this action must have access to
 
 The easiest way to attach these scopes to your credential is by subscribing the credential to the **I/O Management API** in the Developer Console.
 
-These scopes must also be added to the **SCOPES** environment variable specified above. While each scope may be added individually, the easiest way to ensure these scopes are requested during token generation is by adding the `ent_adobeio_sdk` super-scope: 
+The only way to ensure these scopes are requested during token generation is to add the `ent_adobeio_sdk` super-scope to the **SCOPES** environment variable specified above: 
 
-- `["other_scope_1", "other_scope_2", "ent_adobeio_sdk"]`
+- `["ent_adobeio_sdk"]`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ This Github action supports following commands
       2) CLIENTSECRET - Client secret for the Adobe I/O console project
       3) TECHNICALACCOUNTID - Technical account Id for the Adobe I/O console project
       4) IMSORGID - IMS Org Id
-      5) SCOPES - Bracket-enclosed, double-quoted, and comma-separated list of required meta scopes for JWT token
-          - Example: `["meta_scope1", "meta_scope2"]`
-      6) KEY - Private key associated with project
+      5) KEY - Private key associated with project
 
 ## Command Usage and required params
 You can include the action in your workflow as adobe/aio-apps-action@<latest version> Example :
@@ -138,7 +136,6 @@ jobs:
           CLIENTSECRET: ${{ secrets.CLIENTSECRET_PROD }}
           TECHNICALACCOUNTID: ${{ secrets.TECHNICALACCID_PROD }}
           IMSORGID: ${{ secrets.IMSORGID_PROD }}
-          SCOPES: ${{ secrets.SCOPES_PROD }}
           KEY: ${{ secrets.KEY_PROD }}
       - name: Build
         env:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,19 @@ jobs:
           noPublish: false
 ```
 
- ## Contributing
+#### Required scopes
+
+To deploy an extension, the credential used with this action must have access to the following scopes: 
+
+- `AdobeID, openid, read_organizations, additional_info.projectedProductContext, additional_info.roles, adobeio_api, read_client_secret, manage_client_secrets`
+
+The easiest way to attach these scopes to your credential is by subscribing the credential to the **I/O Management API** in the Developer Console.
+
+These scopes must also be added to the **SCOPES** environment variable specified above. While each scope may be added individually, the easiest way to ensure these scopes are requested during token generation is by adding the `ent_adobeio_sdk` super-scope: 
+
+- `["other_scope_1", "other_scope_2", "ent_adobeio_sdk"]`
+
+## Contributing
 
 Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING.md) for more information.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -108832,10 +108832,11 @@ function generateAuthToken() {
     core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
-    console.log('e', JSON.stringify(e))
+    console.log('e', e)
     console.log('e.message', e.message)
-    // core.setFailed(e.message)
-    core.setFailed('sorry didnt work')
+    console.log('e.error', e.error)
+    console.log('e.error_description', e.error_description)
+    core.setFailed(e.message)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -104,6 +104,8 @@ function generateAuthToken() {
       console.error(`
         Invalid scope(s) provided in SCOPES variable, please provide a list of valid scopes.
         If you are providing a valid list of scopes, you may need to add the I/O Management API to your credential in the Developer Console.
+
+        More information on scopes can be found in the README: https://github.com/adobe/aio-apps-action/tree/master#required-scopes
       `)
     }
     core.setFailed(e.message)

--- a/index.js
+++ b/index.js
@@ -102,7 +102,8 @@ function generateAuthToken() {
   .catch(e => {
     console.log('e', JSON.stringify(e))
     console.log('e.message', e.message)
-    core.setFailed(e.message)
+    // core.setFailed(e.message)
+    core.setFailed('sorry didnt work')
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -109,11 +109,16 @@ function generateAuthToken() {
   //generate jwt auth
   const key = core.getInput('key')
 
-  const scopes = core.getInput('scopes') || ["ent_adobeio_sdk"]
-  const parsedScopes = JSON.parse(scopes)
+  let scopes = ["ent_adobeio_sdk"]
 
-  if (!Array.isArray(parsedScopes)) {
-    throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+  // check if custom scopes were configured
+  const scopesInput = core.getInput('scopes')
+  if (scopesInput) {
+    const parsedScopes = JSON.parse(scopesInput)
+    if (!Array.isArray(parsedScopes)) {
+      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+    }
+    scopes = parsedScopes
   }
 
   const clientId = core.getInput('clientId')
@@ -131,7 +136,7 @@ function generateAuthToken() {
     ims_org_id: imsOrgId,
     private_key: key.toString(),
     meta_scopes: [
-      parsedScopes
+      scopes
     ]
   }
 
@@ -147,8 +152,9 @@ function generateAuthToken() {
         Invalid scopes requested during auth command. 
         
         You may need to add the I/O Management API to your credential using either the Developer Console or the aio CLI (e.g. aio app add service).
+
+        Otherwise, if custom scopes were configured using the SCOPES variable, please ensure that the credential has access to the configured scopes by inspecting the credential in the Developer Console.
       `
-      console.error(scopesErrorMsg)
       errorMsg = scopesErrorMsg
     }
     core.setFailed(errorMsg)

--- a/index.js
+++ b/index.js
@@ -100,6 +100,8 @@ function generateAuthToken() {
     core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
+    console.log('e', JSON.stringify(e))
+    console.log('e.message', e.message)
     core.setFailed(e.message)
   })
 }

--- a/index.js
+++ b/index.js
@@ -78,6 +78,20 @@ function generateAuthToken() {
 
   const imsOrgId = core.getInput('imsOrgId')
 
+  if (!scopes) {
+    throw new Error('SCOPES environment variable must be defined to use the auth command')
+  }
+
+  if (!Array.isArray(scopes)) {
+    throw new Error('SCOPES environment variable must be an array of strings (e.g. ["ent_adobeio_sdk"]) to use the auth command')
+  }
+
+  if (
+    !scopes.includes('ent_adobeio_sdk')
+    ) {
+    throw new Error('SCOPES environment variable must include the "ent_adobeio_sdk" scope (e.g. ["ent_adobeio_sdk"]) to use the auth command')
+  }
+
   const imsConfig = {
     client_id : clientId,
     client_secret: clientSecret,

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ try {
   console.log(`Executing command ${command}!`)
   runCLICommand(os, commandStr)
   .then(() => {
-    console.log("action completed2")
+    console.log("action completed")
   })
   .catch(e => {
     core.setFailed(e.message);

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ try {
   console.log(`Executing command ${command}!`)
   runCLICommand(os, commandStr)
   .then(() => {
-    console.log("action completed")
+    console.log("action completed2")
   })
   .catch(e => {
     core.setFailed(e.message);

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function generateAuthToken() {
   try {
     parsedScopes = JSON.parse(scopes)
   } catch (err) {
-    throw new Error('SCOPES environment variable must be a valid array of strings with double-quotes (e.g. ["ent_adobeio_sdk"]) to use the auth command')
+    throw new Error('SCOPES environment variable must be a valid array of strings with double quotes (e.g. ["ent_adobeio_sdk"]) to use the auth command')
   }
 
   if (!parsedScopes) {
@@ -90,7 +90,7 @@ function generateAuthToken() {
   }
 
   if (!Array.isArray(parsedScopes)) {
-    throw new Error('SCOPES environment variable must be an array of strings with double-quotes (e.g. ["test_scope"]) to use the auth command')
+    throw new Error('SCOPES environment variable must be an array of strings with double quotes (e.g. ["test_scope"]) to use the auth command')
   }
 
   if (!parsedScopes.includes('ent_adobeio_sdk')) {

--- a/index.js
+++ b/index.js
@@ -121,12 +121,12 @@ function generateAuthToken() {
     try {
       parsedScopes = JSON.parse(scopesInput)
     } catch (err) {
-      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["meta_scope_1"\]) to use the auth command')
     }
 
     // If not an array, not valid format
     if (!Array.isArray(parsedScopes)) {
-      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["meta_scope_1"\]) to use the auth command')
     }
     scopes = parsedScopes
   }

--- a/index.js
+++ b/index.js
@@ -78,14 +78,19 @@ function generateAuthToken() {
 
   const imsOrgId = core.getInput('imsOrgId')
 
-  const parsedScopes = JSON.parse(scopes)
+  let parsedScopes
+  try {
+    parsedScopes = JSON.parse(scopes)
+  } catch (err) {
+    throw new Error('SCOPES environment variable must be a valid array of strings with double-quotes (e.g. ["ent_adobeio_sdk"]) to use the auth command')
+  }
 
   if (!parsedScopes) {
     throw new Error('SCOPES environment variable must be defined to use the auth command')
   }
 
   if (!Array.isArray(parsedScopes)) {
-    throw new Error('SCOPES environment variable must be an array of strings (e.g. ["test_scope"]) to use the auth command')
+    throw new Error('SCOPES environment variable must be an array of strings with double-quotes (e.g. ["test_scope"]) to use the auth command')
   }
 
   if (!parsedScopes.includes('ent_adobeio_sdk')) {

--- a/index.js
+++ b/index.js
@@ -88,9 +88,7 @@ function generateAuthToken() {
     throw new Error('SCOPES environment variable must be an array of strings (e.g. ["test_scope"]) to use the auth command')
   }
 
-  if (
-    !parsedScopes.includes('ent_adobeio_sdk')
-    ) {
+  if (!parsedScopes.includes('ent_adobeio_sdk')) {
     throw new Error('SCOPES environment variable must include the "ent_adobeio_sdk" scope (e.g. ["ent_adobeio_sdk"]) to use the auth command')
   }
 

--- a/index.js
+++ b/index.js
@@ -111,10 +111,20 @@ function generateAuthToken() {
 
   let scopes = ["ent_adobeio_sdk"]
 
-  // check if custom scopes were configured
+  // check if custom scopes were configured,
+  // must be of format ["ent_adobeio_sdk"]
   const scopesInput = core.getInput('scopes')
+  let parsedScopes
   if (scopesInput) {
-    const parsedScopes = JSON.parse(scopesInput)
+
+    // If JSON parsing fails, not valid format
+    try {
+      parsedScopes = JSON.parse(scopesInput)
+    } catch (err) {
+      throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+    }
+
+    // If not an array, not valid format
     if (!Array.isArray(parsedScopes)) {
       throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
     }

--- a/index.js
+++ b/index.js
@@ -100,8 +100,12 @@ function generateAuthToken() {
     core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
-    console.log('e.error.error', e.error.error)
-    console.log('e.error.error_description', e.error.error_description)
+    if(e.error.error === 'invalid_scope') {
+      console.error(`
+        Invalid scope(s) provided in SCOPES variable, please provide a list of valid scopes.
+        If you are providing a valid list of scopes, you may need to add the I/O Management API to your credential in the Developer Console.
+      `)
+    }
     core.setFailed(e.message)
   })
 }

--- a/index.js
+++ b/index.js
@@ -100,10 +100,8 @@ function generateAuthToken() {
     core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
-    console.log('e', e)
-    console.log('e.message', e.message)
-    console.log('e.error', e.error)
-    console.log('e.error_description', e.error_description)
+    console.log('e.error.error', e.error.error)
+    console.log('e.error.error_description', e.error.error_description)
     core.setFailed(e.message)
   })
 }

--- a/index.js
+++ b/index.js
@@ -109,7 +109,12 @@ function generateAuthToken() {
   //generate jwt auth
   const key = core.getInput('key')
 
-  const requiredScopes = ["ent_adobeio_sdk"]
+  const scopes = core.getInput('scopes') || ["ent_adobeio_sdk"]
+  const parsedScopes = JSON.parse(scopes)
+
+  if (!Array.isArray(parsedScopes)) {
+    throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+  }
 
   const clientId = core.getInput('clientId')
 
@@ -125,7 +130,9 @@ function generateAuthToken() {
     technical_account_id: techAccId,
     ims_org_id: imsOrgId,
     private_key: key.toString(),
-    meta_scopes: requiredScopes
+    meta_scopes: [
+      parsedScopes
+    ]
   }
 
   getAuthToken(imsConfig)

--- a/index.js
+++ b/index.js
@@ -78,16 +78,18 @@ function generateAuthToken() {
 
   const imsOrgId = core.getInput('imsOrgId')
 
-  if (!scopes) {
+  const parsedScopes = JSON.parse(scopes)
+
+  if (!parsedScopes) {
     throw new Error('SCOPES environment variable must be defined to use the auth command')
   }
 
-  if (!Array.isArray(scopes)) {
-    throw new Error('SCOPES environment variable must be an array of strings (e.g. ["ent_adobeio_sdk"]) to use the auth command')
+  if (!Array.isArray(parsedScopes)) {
+    throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
   }
 
   if (
-    !scopes.includes('ent_adobeio_sdk')
+    !parsedScopes.includes('ent_adobeio_sdk')
     ) {
     throw new Error('SCOPES environment variable must include the "ent_adobeio_sdk" scope (e.g. ["ent_adobeio_sdk"]) to use the auth command')
   }

--- a/index.js
+++ b/index.js
@@ -100,10 +100,11 @@ function generateAuthToken() {
     core.exportVariable('AIO_IMS_CONTEXTS_CLI_ACCESS__TOKEN_EXPIRY', expiry)
   })
   .catch(e => {
-    console.log('e', JSON.stringify(e))
+    console.log('e', e)
     console.log('e.message', e.message)
-    // core.setFailed(e.message)
-    core.setFailed('sorry didnt work')
+    console.log('e.error', e.error)
+    console.log('e.error_description', e.error_description)
+    core.setFailed(e.message)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function generateAuthToken() {
   }
 
   if (!Array.isArray(parsedScopes)) {
-    throw new Error('SCOPES environment variable must be an array of strings (e.g. \["ent_adobeio_sdk"\]) to use the auth command')
+    throw new Error('SCOPES environment variable must be an array of strings (e.g. ["test_scope"]) to use the auth command')
   }
 
   if (
@@ -100,9 +100,7 @@ function generateAuthToken() {
     technical_account_id: techAccId,
     ims_org_id: imsOrgId,
     private_key: key.toString(),
-    meta_scopes: [
-      scopes
-    ]
+    meta_scopes: parsedScopes
   }
 
   getJwtToken(imsConfig)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint index.js",
     "test": "npm run lint",
-    "package": "./node_modules/@vercel/ncc/dist/ncc/cli.js build index.js -o dist/"
+    "package": "ncc build index.js -o dist/"
   },
   "dependencies": {
     "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint index.js",
     "test": "npm run lint",
-    "package": "ncc build index.js -o dist/"
+    "package": "./node_modules/@vercel/ncc/dist/ncc/cli.js build index.js -o dist/"
   },
   "dependencies": {
     "@actions/core": "^1.2.6",
@@ -13,7 +13,7 @@
     "@adobe/aio-lib-ims": "6.3.0"
   },
   "devDependencies": {
-    "@zeit/ncc": "^0.22.3",
+    "@vercel/ncc": "^0.38.1",
     "eslint": "^8.41.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
-    "@adobe/aio-lib-ims": "6.3.0"
+    "@adobe/aio-lib-ims": "4.2.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",


### PR DESCRIPTION
## Description

- Make scope configuration for **auth** step optional, add default of **ent_adobeio_sdk** scope (jwt only)
- Add a more descriptive error to deploy output when auth fails if the scopes are invalid
- Add formatting checks for optional SCOPES variable (jwt only)
- Move from @zeit/ncc to @vercel/ncc

## Related Issue

https://github.com/adobe/aio-apps-action/issues/42

## Motivation and Context

## How Has This Been Tested?

Set up this action in a personal repo and pointed it to this branch 

(These could probably be unit tests of some sort)

[Successful deploy with default scopes](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7628361436)

[Successful deploy with configured scopes](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7630163203/job/20785218584)

[Failed deploy, configured scopes have wrong format](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7630191276/job/20785748868#step:6:17)

[Failed deploy, credential doesn't have access to the requested scopes](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7630385986/job/20785930729#step:6:15)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
