### PR TITLE
feat: default oauth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This Github action supports following commands
     - (Optional) If the credential already has scopes attached that allow access to the Extension Registry API and Developer Console API, see the optional **auth** step below for how to configure the custom **SCOPES** variable to request a specific set of scopes.
  
 5) `oauth_sts` - Generates OAuth Server-To-Server based IMS Token and adds that to Github Action Environment for AIO CLI to use. The token is required to build and deploy App Builder [Extensions](https://www.adobe.io/app-builder/docs/guides/extensions/).
+    * OAuth Credential used in this step must have scopes attached that allow interaction with the Extension Registry API and Developer Console API. This can be achieved by adding the **I/O Management API** to the credential in the Developer Console. The appropriate scopes will then be automatically requested and attached to the token generated during this step.
+    - (Optional) If the credential already has scopes attached that allow access to the Extension Registry API and Developer Console API, see the optional **oauth_sts** step below for how to configure the custom **SCOPES** variable to request a specific set of scopes.
 
 ## Prerequisites for Commands
 
@@ -56,7 +58,7 @@ This Github action supports following commands
       3) TECHNICALACCOUNTID - Technical account Id of Adobe I/O console project
       4) TECHNICALACCOUNTEMAIL -  Technical account email of Adobe I/O console project
       5) IMSORGID - IMS Org Id
-      6) SCOPES - comma-separated list of scopes for OAuth Server-To-Server Credentials
+      6) (optional) SCOPES - comma-separated list of scopes for OAuth Server-To-Server Credentials
           - Example: `AdobeID, openid, read_organizations`
 
 ## Command Usage and required params

--- a/dist/index.js
+++ b/dist/index.js
@@ -114361,9 +114361,7 @@ async function generateOAuthSTSAuthToken (params = {}) {
   const schema = {
     type: 'object',
     properties: {
-      // (Need the \s for spaces in the regex)
-      // eslint-disable-next-line no-useless-escape
-      scopes: { type: 'string', pattern: '^([a-zA-Z0-9_.\s]+,)*([a-zA-Z0-9_.\s]+){1}' }, // Comma-separated string with or without spaces
+      scopes: { type: 'string' },
       clientId: { type: 'string' },
       clientSecret: { type: 'string' },
       techAccId: { type: 'string' },
@@ -114383,12 +114381,8 @@ async function generateOAuthSTSAuthToken (params = {}) {
     : [
         'AdobeID',
         'openid',
-        'read_organizations',
-        'additional_info.projectedProductContext',
-        'additional_info.roles',
         'adobeio_api',
-        'read_client_secret',
-        'manage_client_secrets'
+        'read_client_secret'
       ]
 
   // generate oauth sts auth token

--- a/dist/index.js
+++ b/dist/index.js
@@ -114379,10 +114379,15 @@ async function generateOAuthSTSAuthToken (params = {}) {
   const finalScopes = scopes
     ? scopes.split(',')
     : [
-        'AdobeID',
-        'openid',
-        'adobeio_api',
-        'read_client_secret'
+        // Scopes granted by I/O Management API
+        'AdobeID', 
+        'openid', 
+        'read_organizations', 
+        'additional_info.projectedProductContext', 
+        'additional_info.roles', 
+        'adobeio_api', 
+        'read_client_secret', 
+        'manage_client_secrets'
       ]
 
   // generate oauth sts auth token

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "description": "GitHub Action to Build, Test and Deploy AIO Apps",
   "scripts": {
+    "lint-fix": "npm run lint -- --fix",
     "lint": "eslint src test",
     "test": "npm run unit-tests && npm run lint && npm run package",
     "unit-tests": "jest -c jest.config.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,13 +71,22 @@ async function generateOAuthSTSAuthToken (params = {}) {
       techAccEmail: { type: 'string' },
       imsOrgId: { type: 'string' }
     },
-    required: ['scopes', 'clientId', 'clientSecret', 'techAccId', 'techAccEmail', 'imsOrgId']
+    required: ['clientId', 'clientSecret', 'techAccId', 'techAccEmail', 'imsOrgId']
   }
 
   const { valid, errors } = validate(schema, params)
   if (!valid) {
     throw new Error(`[generateOAuthSTSAuthToken] Validation errors: ${JSON.stringify(errors, null, 2)}`)
   }
+
+  const finalScopes = scopes
+    ? scopes.split(',')
+    : [
+        'AdobeID',
+        'openid',
+        'adobeio_api',
+        'read_client_secret'
+      ]
 
   // generate oauth sts auth token
   console.log('Trying to generate oauth sts token')
@@ -88,7 +97,9 @@ async function generateOAuthSTSAuthToken (params = {}) {
     technical_account_email: techAccEmail,
     technical_account_id: techAccId,
     ims_org_id: imsOrgId,
-    scopes: scopes.split(',')
+    scopes: [
+      ...finalScopes
+    ]
   }
   return getAuthToken(ims, imsContextConfig)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,10 +82,15 @@ async function generateOAuthSTSAuthToken (params = {}) {
   const finalScopes = scopes
     ? scopes.split(',')
     : [
-        'AdobeID',
-        'openid',
-        'adobeio_api',
-        'read_client_secret'
+        // Scopes granted by I/O Management API
+        'AdobeID', 
+        'openid', 
+        'read_organizations', 
+        'additional_info.projectedProductContext', 
+        'additional_info.roles', 
+        'adobeio_api', 
+        'read_client_secret', 
+        'manage_client_secrets'
       ]
 
   // generate oauth sts auth token

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,13 +83,13 @@ async function generateOAuthSTSAuthToken (params = {}) {
     ? scopes.split(',')
     : [
         // Scopes granted by I/O Management API
-        'AdobeID', 
-        'openid', 
-        'read_organizations', 
-        'additional_info.projectedProductContext', 
-        'additional_info.roles', 
-        'adobeio_api', 
-        'read_client_secret', 
+        'AdobeID',
+        'openid',
+        'read_organizations',
+        'additional_info.projectedProductContext',
+        'additional_info.roles',
+        'adobeio_api',
+        'read_client_secret',
         'manage_client_secrets'
       ]
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -198,6 +198,33 @@ describe('generateOAuthSTSAuthToken', () => {
     await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
   })
 
+  test('use default scopes', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id'
+    }
+    const token = 'my-token'
+    ims.getToken.mockResolvedValue(token)
+    await expect(generateOAuthSTSAuthToken(inputs)).resolves.toEqual(token)
+    expect(ims.context.set).toHaveBeenCalledWith('genToken', expect.objectContaining({
+      scopes: [
+        'AdobeID',
+        'openid',
+        'read_organizations',
+        'additional_info.projectedProductContext',
+        'additional_info.roles',
+        'adobeio_api',
+        'read_client_secret',
+        'manage_client_secrets'
+      ]
+    }), true)
+  })
+
   test('all required inputs available', async () => {
     const inputs = {
       ims,


### PR DESCRIPTION
## Description

Add default scopes to oauth step, so users can add I/O Management API to their credential and skip scope config

Scope configuration is still possible, but with this it'd be optional

(Note: default scopes are already supported with the deprecated jwt step, this is bringing oauth up to par with that)

## Related Issue

[ACNA-2762](https://jira.corp.adobe.com/browse/ACNA-2762)

## Motivation and Context

## How Has This Been Tested?
`npm run test`

[Real test using default scopes ](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7729367137/job/21072354956)

[Real test using configured scopes](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7729340138/job/21072261918)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
