### PR TITLE
feat: validate oauth scope format

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27527,6 +27527,288 @@ exports["default"] = promisify;
 
 /***/ }),
 
+/***/ 50424:
+/***/ ((module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const ajv_1 = __nccwpck_require__(72426);
+const codegen_1 = __nccwpck_require__(19179);
+const code_1 = __nccwpck_require__(58358);
+const validate_1 = __nccwpck_require__(18955);
+const errors_1 = __nccwpck_require__(28048);
+const names_1 = __nccwpck_require__(10050);
+const keyword = "errorMessage";
+const used = new ajv_1.Name("emUsed");
+const KEYWORD_PROPERTY_PARAMS = {
+    required: "missingProperty",
+    dependencies: "property",
+    dependentRequired: "property",
+};
+const INTERPOLATION = /\$\{[^}]+\}/;
+const INTERPOLATION_REPLACE = /\$\{([^}]+)\}/g;
+const EMPTY_STR = /^""\s*\+\s*|\s*\+\s*""$/g;
+function errorMessage(options) {
+    return {
+        keyword,
+        schemaType: ["string", "object"],
+        post: true,
+        code(cxt) {
+            const { gen, data, schema, schemaValue, it } = cxt;
+            if (it.createErrors === false)
+                return;
+            const sch = schema;
+            const instancePath = codegen_1.strConcat(names_1.default.instancePath, it.errorPath);
+            gen.if(ajv_1._ `${names_1.default.errors} > 0`, () => {
+                if (typeof sch == "object") {
+                    const [kwdPropErrors, kwdErrors] = keywordErrorsConfig(sch);
+                    if (kwdErrors)
+                        processKeywordErrors(kwdErrors);
+                    if (kwdPropErrors)
+                        processKeywordPropErrors(kwdPropErrors);
+                    processChildErrors(childErrorsConfig(sch));
+                }
+                const schMessage = typeof sch == "string" ? sch : sch._;
+                if (schMessage)
+                    processAllErrors(schMessage);
+                if (!options.keepErrors)
+                    removeUsedErrors();
+            });
+            function childErrorsConfig({ properties, items }) {
+                const errors = {};
+                if (properties) {
+                    errors.props = {};
+                    for (const p in properties)
+                        errors.props[p] = [];
+                }
+                if (items) {
+                    errors.items = {};
+                    for (let i = 0; i < items.length; i++)
+                        errors.items[i] = [];
+                }
+                return errors;
+            }
+            function keywordErrorsConfig(emSchema) {
+                let propErrors;
+                let errors;
+                for (const k in emSchema) {
+                    if (k === "properties" || k === "items")
+                        continue;
+                    const kwdSch = emSchema[k];
+                    if (typeof kwdSch == "object") {
+                        propErrors || (propErrors = {});
+                        const errMap = (propErrors[k] = {});
+                        for (const p in kwdSch)
+                            errMap[p] = [];
+                    }
+                    else {
+                        errors || (errors = {});
+                        errors[k] = [];
+                    }
+                }
+                return [propErrors, errors];
+            }
+            function processKeywordErrors(kwdErrors) {
+                const kwdErrs = gen.const("emErrors", ajv_1.stringify(kwdErrors));
+                const templates = gen.const("templates", getTemplatesCode(kwdErrors, schema));
+                gen.forOf("err", names_1.default.vErrors, (err) => gen.if(matchKeywordError(err, kwdErrs), () => gen.code(ajv_1._ `${kwdErrs}[${err}.keyword].push(${err})`).assign(ajv_1._ `${err}.${used}`, true)));
+                const { singleError } = options;
+                if (singleError) {
+                    const message = gen.let("message", ajv_1._ `""`);
+                    const paramsErrors = gen.let("paramsErrors", ajv_1._ `[]`);
+                    loopErrors((key) => {
+                        gen.if(message, () => gen.code(ajv_1._ `${message} += ${typeof singleError == "string" ? singleError : ";"}`));
+                        gen.code(ajv_1._ `${message} += ${errMessage(key)}`);
+                        gen.assign(paramsErrors, ajv_1._ `${paramsErrors}.concat(${kwdErrs}[${key}])`);
+                    });
+                    errors_1.reportError(cxt, { message, params: ajv_1._ `{errors: ${paramsErrors}}` });
+                }
+                else {
+                    loopErrors((key) => errors_1.reportError(cxt, {
+                        message: errMessage(key),
+                        params: ajv_1._ `{errors: ${kwdErrs}[${key}]}`,
+                    }));
+                }
+                function loopErrors(body) {
+                    gen.forIn("key", kwdErrs, (key) => gen.if(ajv_1._ `${kwdErrs}[${key}].length`, () => body(key)));
+                }
+                function errMessage(key) {
+                    return ajv_1._ `${key} in ${templates} ? ${templates}[${key}]() : ${schemaValue}[${key}]`;
+                }
+            }
+            function processKeywordPropErrors(kwdPropErrors) {
+                const kwdErrs = gen.const("emErrors", ajv_1.stringify(kwdPropErrors));
+                const templatesCode = [];
+                for (const k in kwdPropErrors) {
+                    templatesCode.push([
+                        k,
+                        getTemplatesCode(kwdPropErrors[k], schema[k]),
+                    ]);
+                }
+                const templates = gen.const("templates", gen.object(...templatesCode));
+                const kwdPropParams = gen.scopeValue("obj", {
+                    ref: KEYWORD_PROPERTY_PARAMS,
+                    code: ajv_1.stringify(KEYWORD_PROPERTY_PARAMS),
+                });
+                const propParam = gen.let("emPropParams");
+                const paramsErrors = gen.let("emParamsErrors");
+                gen.forOf("err", names_1.default.vErrors, (err) => gen.if(matchKeywordError(err, kwdErrs), () => {
+                    gen.assign(propParam, ajv_1._ `${kwdPropParams}[${err}.keyword]`);
+                    gen.assign(paramsErrors, ajv_1._ `${kwdErrs}[${err}.keyword][${err}.params[${propParam}]]`);
+                    gen.if(paramsErrors, () => gen.code(ajv_1._ `${paramsErrors}.push(${err})`).assign(ajv_1._ `${err}.${used}`, true));
+                }));
+                gen.forIn("key", kwdErrs, (key) => gen.forIn("keyProp", ajv_1._ `${kwdErrs}[${key}]`, (keyProp) => {
+                    gen.assign(paramsErrors, ajv_1._ `${kwdErrs}[${key}][${keyProp}]`);
+                    gen.if(ajv_1._ `${paramsErrors}.length`, () => {
+                        const tmpl = gen.const("tmpl", ajv_1._ `${templates}[${key}] && ${templates}[${key}][${keyProp}]`);
+                        errors_1.reportError(cxt, {
+                            message: ajv_1._ `${tmpl} ? ${tmpl}() : ${schemaValue}[${key}][${keyProp}]`,
+                            params: ajv_1._ `{errors: ${paramsErrors}}`,
+                        });
+                    });
+                }));
+            }
+            function processChildErrors(childErrors) {
+                const { props, items } = childErrors;
+                if (!props && !items)
+                    return;
+                const isObj = ajv_1._ `typeof ${data} == "object"`;
+                const isArr = ajv_1._ `Array.isArray(${data})`;
+                const childErrs = gen.let("emErrors");
+                let childKwd;
+                let childProp;
+                const templates = gen.let("templates");
+                if (props && items) {
+                    childKwd = gen.let("emChildKwd");
+                    gen.if(isObj);
+                    gen.if(isArr, () => {
+                        init(items, schema.items);
+                        gen.assign(childKwd, ajv_1.str `items`);
+                    }, () => {
+                        init(props, schema.properties);
+                        gen.assign(childKwd, ajv_1.str `properties`);
+                    });
+                    childProp = ajv_1._ `[${childKwd}]`;
+                }
+                else if (items) {
+                    gen.if(isArr);
+                    init(items, schema.items);
+                    childProp = ajv_1._ `.items`;
+                }
+                else if (props) {
+                    gen.if(codegen_1.and(isObj, codegen_1.not(isArr)));
+                    init(props, schema.properties);
+                    childProp = ajv_1._ `.properties`;
+                }
+                gen.forOf("err", names_1.default.vErrors, (err) => ifMatchesChildError(err, childErrs, (child) => gen.code(ajv_1._ `${childErrs}[${child}].push(${err})`).assign(ajv_1._ `${err}.${used}`, true)));
+                gen.forIn("key", childErrs, (key) => gen.if(ajv_1._ `${childErrs}[${key}].length`, () => {
+                    errors_1.reportError(cxt, {
+                        message: ajv_1._ `${key} in ${templates} ? ${templates}[${key}]() : ${schemaValue}${childProp}[${key}]`,
+                        params: ajv_1._ `{errors: ${childErrs}[${key}]}`,
+                    });
+                    gen.assign(ajv_1._ `${names_1.default.vErrors}[${names_1.default.errors}-1].instancePath`, ajv_1._ `${instancePath} + "/" + ${key}.replace(/~/g, "~0").replace(/\\//g, "~1")`);
+                }));
+                gen.endIf();
+                function init(children, msgs) {
+                    gen.assign(childErrs, ajv_1.stringify(children));
+                    gen.assign(templates, getTemplatesCode(children, msgs));
+                }
+            }
+            function processAllErrors(schMessage) {
+                const errs = gen.const("emErrs", ajv_1._ `[]`);
+                gen.forOf("err", names_1.default.vErrors, (err) => gen.if(matchAnyError(err), () => gen.code(ajv_1._ `${errs}.push(${err})`).assign(ajv_1._ `${err}.${used}`, true)));
+                gen.if(ajv_1._ `${errs}.length`, () => errors_1.reportError(cxt, {
+                    message: templateExpr(schMessage),
+                    params: ajv_1._ `{errors: ${errs}}`,
+                }));
+            }
+            function removeUsedErrors() {
+                const errs = gen.const("emErrs", ajv_1._ `[]`);
+                gen.forOf("err", names_1.default.vErrors, (err) => gen.if(ajv_1._ `!${err}.${used}`, () => gen.code(ajv_1._ `${errs}.push(${err})`)));
+                gen.assign(names_1.default.vErrors, errs).assign(names_1.default.errors, ajv_1._ `${errs}.length`);
+            }
+            function matchKeywordError(err, kwdErrs) {
+                return codegen_1.and(ajv_1._ `${err}.keyword !== ${keyword}`, ajv_1._ `!${err}.${used}`, ajv_1._ `${err}.instancePath === ${instancePath}`, ajv_1._ `${err}.keyword in ${kwdErrs}`, 
+                // TODO match the end of the string?
+                ajv_1._ `${err}.schemaPath.indexOf(${it.errSchemaPath}) === 0`, ajv_1._ `/^\\/[^\\/]*$/.test(${err}.schemaPath.slice(${it.errSchemaPath.length}))`);
+            }
+            function ifMatchesChildError(err, childErrs, thenBody) {
+                gen.if(codegen_1.and(ajv_1._ `${err}.keyword !== ${keyword}`, ajv_1._ `!${err}.${used}`, ajv_1._ `${err}.instancePath.indexOf(${instancePath}) === 0`), () => {
+                    const childRegex = gen.scopeValue("pattern", {
+                        ref: /^\/([^/]*)(?:\/|$)/,
+                        code: ajv_1._ `new RegExp("^\\\/([^/]*)(?:\\\/|$)")`,
+                    });
+                    const matches = gen.const("emMatches", ajv_1._ `${childRegex}.exec(${err}.instancePath.slice(${instancePath}.length))`);
+                    const child = gen.const("emChild", ajv_1._ `${matches} && ${matches}[1].replace(/~1/g, "/").replace(/~0/g, "~")`);
+                    gen.if(ajv_1._ `${child} !== undefined && ${child} in ${childErrs}`, () => thenBody(child));
+                });
+            }
+            function matchAnyError(err) {
+                return codegen_1.and(ajv_1._ `${err}.keyword !== ${keyword}`, ajv_1._ `!${err}.${used}`, codegen_1.or(ajv_1._ `${err}.instancePath === ${instancePath}`, codegen_1.and(ajv_1._ `${err}.instancePath.indexOf(${instancePath}) === 0`, ajv_1._ `${err}.instancePath[${instancePath}.length] === "/"`)), ajv_1._ `${err}.schemaPath.indexOf(${it.errSchemaPath}) === 0`, ajv_1._ `${err}.schemaPath[${it.errSchemaPath}.length] === "/"`);
+            }
+            function getTemplatesCode(keys, msgs) {
+                const templatesCode = [];
+                for (const k in keys) {
+                    const msg = msgs[k];
+                    if (INTERPOLATION.test(msg))
+                        templatesCode.push([k, templateFunc(msg)]);
+                }
+                return gen.object(...templatesCode);
+            }
+            function templateExpr(msg) {
+                if (!INTERPOLATION.test(msg))
+                    return ajv_1.stringify(msg);
+                return new code_1._Code(code_1.safeStringify(msg)
+                    .replace(INTERPOLATION_REPLACE, (_s, ptr) => `" + JSON.stringify(${validate_1.getData(ptr, it)}) + "`)
+                    .replace(EMPTY_STR, ""));
+            }
+            function templateFunc(msg) {
+                return ajv_1._ `function(){return ${templateExpr(msg)}}`;
+            }
+        },
+        metaSchema: {
+            anyOf: [
+                { type: "string" },
+                {
+                    type: "object",
+                    properties: {
+                        properties: { $ref: "#/$defs/stringMap" },
+                        items: { $ref: "#/$defs/stringList" },
+                        required: { $ref: "#/$defs/stringOrMap" },
+                        dependencies: { $ref: "#/$defs/stringOrMap" },
+                    },
+                    additionalProperties: { type: "string" },
+                },
+            ],
+            $defs: {
+                stringMap: {
+                    type: "object",
+                    additionalProperties: { type: "string" },
+                },
+                stringOrMap: {
+                    anyOf: [{ type: "string" }, { $ref: "#/$defs/stringMap" }],
+                },
+                stringList: { type: "array", items: { type: "string" } },
+            },
+        },
+    };
+}
+const ajvErrors = (ajv, options = {}) => {
+    if (!ajv.opts.allErrors)
+        throw new Error("ajv-errors: Ajv option allErrors must be true");
+    if (ajv.opts.jsPropertySyntax) {
+        throw new Error("ajv-errors: ajv option jsPropertySyntax is not supported");
+    }
+    return ajv.addKeyword(errorMessage(options));
+};
+exports["default"] = ajvErrors;
+module.exports = ajvErrors;
+module.exports["default"] = ajvErrors;
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
 /***/ 72426:
 /***/ ((module, exports, __nccwpck_require__) => {
 
@@ -84192,7 +84474,6 @@ const MockAgent = __nccwpck_require__(66771)
 const MockPool = __nccwpck_require__(26193)
 const mockErrors = __nccwpck_require__(50888)
 const ProxyAgent = __nccwpck_require__(97858)
-const RetryHandler = __nccwpck_require__(82286)
 const { getGlobalDispatcher, setGlobalDispatcher } = __nccwpck_require__(21892)
 const DecoratorHandler = __nccwpck_require__(46930)
 const RedirectHandler = __nccwpck_require__(72860)
@@ -84214,7 +84495,6 @@ module.exports.Pool = Pool
 module.exports.BalancedPool = BalancedPool
 module.exports.Agent = Agent
 module.exports.ProxyAgent = ProxyAgent
-module.exports.RetryHandler = RetryHandler
 
 module.exports.DecoratorHandler = DecoratorHandler
 module.exports.RedirectHandler = RedirectHandler
@@ -85115,7 +85395,6 @@ function request (opts, callback) {
 }
 
 module.exports = request
-module.exports.RequestHandler = RequestHandler
 
 
 /***/ }),
@@ -85498,8 +85777,6 @@ const kBody = Symbol('kBody')
 const kAbort = Symbol('abort')
 const kContentType = Symbol('kContentType')
 
-const noop = () => {}
-
 module.exports = class BodyReadable extends Readable {
   constructor ({
     resume,
@@ -85633,50 +85910,37 @@ module.exports = class BodyReadable extends Readable {
     return this[kBody]
   }
 
-  dump (opts) {
+  async dump (opts) {
     let limit = opts && Number.isFinite(opts.limit) ? opts.limit : 262144
     const signal = opts && opts.signal
-
+    const abortFn = () => {
+      this.destroy()
+    }
+    let signalListenerCleanup
     if (signal) {
-      try {
-        if (typeof signal !== 'object' || !('aborted' in signal)) {
-          throw new InvalidArgumentError('signal must be an AbortSignal')
-        }
+      if (typeof signal !== 'object' || !('aborted' in signal)) {
+        throw new InvalidArgumentError('signal must be an AbortSignal')
+      }
+      util.throwIfAborted(signal)
+      signalListenerCleanup = util.addAbortListener(signal, abortFn)
+    }
+    try {
+      for await (const chunk of this) {
         util.throwIfAborted(signal)
-      } catch (err) {
-        return Promise.reject(err)
+        limit -= Buffer.byteLength(chunk)
+        if (limit < 0) {
+          return
+        }
+      }
+    } catch {
+      util.throwIfAborted(signal)
+    } finally {
+      if (typeof signalListenerCleanup === 'function') {
+        signalListenerCleanup()
+      } else if (signalListenerCleanup) {
+        signalListenerCleanup[Symbol.dispose]()
       }
     }
-
-    if (this.closed) {
-      return Promise.resolve(null)
-    }
-
-    return new Promise((resolve, reject) => {
-      const signalListenerCleanup = signal
-        ? util.addAbortListener(signal, () => {
-          this.destroy()
-        })
-        : noop
-
-      this
-        .on('close', function () {
-          signalListenerCleanup()
-          if (signal && signal.aborted) {
-            reject(signal.reason || Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }))
-          } else {
-            resolve(null)
-          }
-        })
-        .on('error', noop)
-        .on('data', function (chunk) {
-          limit -= chunk.length
-          if (limit <= 0) {
-            this.destroy()
-          }
-        })
-        .resume()
-    })
   }
 }
 
@@ -87056,13 +87320,13 @@ module.exports = {
 /***/ }),
 
 /***/ 29174:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ ((module) => {
 
 "use strict";
 
 
 module.exports = {
-  kConstruct: (__nccwpck_require__(72785).kConstruct)
+  kConstruct: Symbol('constructable')
 }
 
 
@@ -88048,9 +88312,11 @@ class Parser {
       socket[kReset] = true
     }
 
-    const pause = request.onHeaders(statusCode, headers, this.resume, statusText) === false
-
-    if (request.aborted) {
+    let pause
+    try {
+      pause = request.onHeaders(statusCode, headers, this.resume, statusText) === false
+    } catch (err) {
+      util.destroy(socket, err)
       return -1
     }
 
@@ -88097,8 +88363,13 @@ class Parser {
 
     this.bytesRead += buf.length
 
-    if (request.onData(buf) === false) {
-      return constants.ERROR.PAUSED
+    try {
+      if (request.onData(buf) === false) {
+        return constants.ERROR.PAUSED
+      }
+    } catch (err) {
+      util.destroy(socket, err)
+      return -1
     }
   }
 
@@ -88139,7 +88410,11 @@ class Parser {
       return -1
     }
 
-    request.onComplete(headers)
+    try {
+      request.onComplete(headers)
+    } catch (err) {
+      errorRequest(client, request, err)
+    }
 
     client[kQueue][client[kRunningIdx]++] = null
 
@@ -88303,7 +88578,7 @@ async function connect (client) {
     const idx = hostname.indexOf(']')
 
     assert(idx !== -1)
-    const ip = hostname.substring(1, idx)
+    const ip = hostname.substr(1, idx - 1)
 
     assert(net.isIP(ip))
     hostname = ip
@@ -88802,7 +89077,6 @@ function writeH2 (client, session, request) {
     return false
   }
 
-  /** @type {import('node:http2').ClientHttp2Stream} */
   let stream
   const h2State = client[kHTTP2SessionState]
 
@@ -88898,10 +89172,14 @@ function writeH2 (client, session, request) {
   const shouldEndStream = method === 'GET' || method === 'HEAD'
   if (expectContinue) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
+    /**
+     * @type {import('node:http2').ClientHttp2Stream}
+     */
     stream = session.request(headers, { endStream: shouldEndStream, signal })
 
     stream.once('continue', writeBodyH2)
   } else {
+    /** @type {import('node:http2').ClientHttp2Stream} */
     stream = session.request(headers, {
       endStream: shouldEndStream,
       signal
@@ -88913,9 +89191,7 @@ function writeH2 (client, session, request) {
   ++h2State.openStreams
 
   stream.once('response', headers => {
-    const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
-
-    if (request.onHeaders(Number(statusCode), realHeaders, stream.resume.bind(stream), '') === false) {
+    if (request.onHeaders(Number(headers[HTTP2_HEADER_STATUS]), headers, stream.resume.bind(stream), '') === false) {
       stream.pause()
     }
   })
@@ -88925,17 +89201,13 @@ function writeH2 (client, session, request) {
   })
 
   stream.on('data', (chunk) => {
-    if (request.onData(chunk) === false) {
-      stream.pause()
-    }
+    if (request.onData(chunk) === false) stream.pause()
   })
 
   stream.once('close', () => {
     h2State.openStreams -= 1
     // TODO(HTTP/2): unref only if current streams count is 0
-    if (h2State.openStreams === 0) {
-      session.unref()
-    }
+    if (h2State.openStreams === 0) session.unref()
   })
 
   stream.once('error', function (err) {
@@ -89095,11 +89367,7 @@ function writeStream ({ h2stream, body, client, request, socket, contentLength, 
     }
   }
   const onAbort = function () {
-    if (finished) {
-      return
-    }
-    const err = new RequestAbortedError()
-    queueMicrotask(() => onFinished(err))
+    onFinished(new RequestAbortedError())
   }
   const onFinished = function (err) {
     if (finished) {
@@ -90704,19 +90972,6 @@ class ResponseExceededMaxSizeError extends UndiciError {
   }
 }
 
-class RequestRetryError extends UndiciError {
-  constructor (message, code, { headers, data }) {
-    super(message)
-    Error.captureStackTrace(this, RequestRetryError)
-    this.name = 'RequestRetryError'
-    this.message = message || 'Request retry error'
-    this.code = 'UND_ERR_REQ_RETRY'
-    this.statusCode = code
-    this.data = data
-    this.headers = headers
-  }
-}
-
 module.exports = {
   HTTPParserError,
   UndiciError,
@@ -90736,8 +90991,7 @@ module.exports = {
   NotSupportedError,
   ResponseContentLengthMismatchError,
   BalancedPoolMissingUpstreamError,
-  ResponseExceededMaxSizeError,
-  RequestRetryError
+  ResponseExceededMaxSizeError
 }
 
 
@@ -90979,9 +91233,9 @@ class Request {
   onBodySent (chunk) {
     if (this[kHandler].onBodySent) {
       try {
-        return this[kHandler].onBodySent(chunk)
+        this[kHandler].onBodySent(chunk)
       } catch (err) {
-        this.abort(err)
+        this.onError(err)
       }
     }
   }
@@ -90993,9 +91247,9 @@ class Request {
 
     if (this[kHandler].onRequestSent) {
       try {
-        return this[kHandler].onRequestSent()
+        this[kHandler].onRequestSent()
       } catch (err) {
-        this.abort(err)
+        this.onError(err)
       }
     }
   }
@@ -91020,23 +91274,14 @@ class Request {
       channels.headers.publish({ request: this, response: { statusCode, headers, statusText } })
     }
 
-    try {
-      return this[kHandler].onHeaders(statusCode, headers, resume, statusText)
-    } catch (err) {
-      this.abort(err)
-    }
+    return this[kHandler].onHeaders(statusCode, headers, resume, statusText)
   }
 
   onData (chunk) {
     assert(!this.aborted)
     assert(!this.completed)
 
-    try {
-      return this[kHandler].onData(chunk)
-    } catch (err) {
-      this.abort(err)
-      return false
-    }
+    return this[kHandler].onData(chunk)
   }
 
   onUpgrade (statusCode, headers, socket) {
@@ -91055,13 +91300,7 @@ class Request {
     if (channels.trailers.hasSubscribers) {
       channels.trailers.publish({ request: this, trailers })
     }
-
-    try {
-      return this[kHandler].onComplete(trailers)
-    } catch (err) {
-      // TODO (fix): This might be a bad idea?
-      this.onError(err)
-    }
+    return this[kHandler].onComplete(trailers)
   }
 
   onError (error) {
@@ -91075,7 +91314,6 @@ class Request {
       return
     }
     this.aborted = true
-
     return this[kHandler].onError(error)
   }
 
@@ -91312,9 +91550,7 @@ module.exports = {
   kHTTP2BuildRequest: Symbol('http2 build request'),
   kHTTP1BuildRequest: Symbol('http1 build request'),
   kHTTP2CopyHeaders: Symbol('http2 copy headers'),
-  kHTTPConnVersion: Symbol('http connection version'),
-  kRetryHandlerDefaultRetry: Symbol('retry agent default retry'),
-  kConstruct: Symbol('constructable')
+  kHTTPConnVersion: Symbol('http connection version')
 }
 
 
@@ -91451,13 +91687,13 @@ function getHostname (host) {
     const idx = host.indexOf(']')
 
     assert(idx !== -1)
-    return host.substring(1, idx)
+    return host.substr(1, idx - 1)
   }
 
   const idx = host.indexOf(':')
   if (idx === -1) return host
 
-  return host.substring(0, idx)
+  return host.substr(0, idx)
 }
 
 // IP addresses are not valid server names per RFC6066
@@ -91554,7 +91790,7 @@ function parseHeaders (headers, obj = {}) {
 
     if (!val) {
       if (Array.isArray(headers[i + 1])) {
-        obj[key] = headers[i + 1].map(x => x.toString('utf8'))
+        obj[key] = headers[i + 1]
       } else {
         obj[key] = headers[i + 1].toString('utf8')
       }
@@ -91757,7 +91993,16 @@ function throwIfAborted (signal) {
   }
 }
 
+let events
 function addAbortListener (signal, listener) {
+  if (typeof Symbol.dispose === 'symbol') {
+    if (!events) {
+      events = __nccwpck_require__(82361)
+    }
+    if (typeof events.addAbortListener === 'function' && 'aborted' in signal) {
+      return events.addAbortListener(signal, listener)
+    }
+  }
   if ('addEventListener' in signal) {
     signal.addEventListener('abort', listener, { once: true })
     return () => signal.removeEventListener('abort', listener)
@@ -91779,21 +92024,6 @@ function toUSVString (val) {
   }
 
   return `${val}`
-}
-
-// Parsed accordingly to RFC 9110
-// https://www.rfc-editor.org/rfc/rfc9110#field.content-range
-function parseRangeHeader (range) {
-  if (range == null || range === '') return { start: 0, end: null, size: null }
-
-  const m = range ? range.match(/^bytes (\d+)-(\d+)\/(\d+)?$/) : null
-  return m
-    ? {
-        start: parseInt(m[1]),
-        end: m[2] ? parseInt(m[2]) : null,
-        size: m[3] ? parseInt(m[3]) : null
-      }
-    : null
 }
 
 const kEnumerableProperty = Object.create(null)
@@ -91829,11 +92059,9 @@ module.exports = {
   buildURL,
   throwIfAborted,
   addAbortListener,
-  parseRangeHeader,
   nodeMajor,
   nodeMinor,
-  nodeHasAutoSelectFamily: nodeMajor > 18 || (nodeMajor === 18 && nodeMinor >= 13),
-  safeHTTPMethods: ['GET', 'HEAD', 'OPTIONS', 'TRACE']
+  nodeHasAutoSelectFamily: nodeMajor > 18 || (nodeMajor === 18 && nodeMinor >= 13)
 }
 
 
@@ -92962,14 +93190,17 @@ function dataURLProcessor (dataURL) {
  * @param {boolean} excludeFragment
  */
 function URLSerializer (url, excludeFragment = false) {
+  const href = url.href
+
   if (!excludeFragment) {
-    return url.href
+    return href
   }
 
-  const href = url.href
-  const hashLength = url.hash.length
-
-  return hashLength === 0 ? href : href.substring(0, href.length - hashLength)
+  const hash = href.lastIndexOf('#')
+  if (hash === -1) {
+    return href
+  }
+  return href.slice(0, hash)
 }
 
 // https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points
@@ -94153,7 +94384,7 @@ module.exports = {
 
 
 
-const { kHeadersList, kConstruct } = __nccwpck_require__(72785)
+const { kHeadersList } = __nccwpck_require__(72785)
 const { kGuard } = __nccwpck_require__(15861)
 const { kEnumerableProperty } = __nccwpck_require__(83983)
 const {
@@ -94168,13 +94399,6 @@ const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
 
 /**
- * @param {number} code
- */
-function isHTTPWhiteSpaceCharCode (code) {
-  return code === 0x00a || code === 0x00d || code === 0x009 || code === 0x020
-}
-
-/**
  * @see https://fetch.spec.whatwg.org/#concept-header-value-normalize
  * @param {string} potentialValue
  */
@@ -94182,12 +94406,12 @@ function headerValueNormalize (potentialValue) {
   //  To normalize a byte sequence potentialValue, remove
   //  any leading and trailing HTTP whitespace bytes from
   //  potentialValue.
-  let i = 0; let j = potentialValue.length
 
-  while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j
-  while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i
-
-  return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.substring(i, j)
+  // Trimming the end with `.replace()` and a RegExp is typically subject to
+  // ReDoS. This is safer and faster.
+  let i = potentialValue.length
+  while (/[\r\n\t ]/.test(potentialValue.charAt(--i)));
+  return potentialValue.slice(0, i + 1).replace(/^[\r\n\t ]+/, '')
 }
 
 function fill (headers, object) {
@@ -94196,8 +94420,7 @@ function fill (headers, object) {
   // 1. If object is a sequence, then for each header in object:
   // Note: webidl conversion to array has already been done.
   if (Array.isArray(object)) {
-    for (let i = 0; i < object.length; ++i) {
-      const header = object[i]
+    for (const header of object) {
       // 1. If header does not contain exactly two items, then throw a TypeError.
       if (header.length !== 2) {
         throw webidl.errors.exception({
@@ -94207,16 +94430,15 @@ function fill (headers, object) {
       }
 
       // 2. Append (header’s first item, header’s second item) to headers.
-      appendHeader(headers, header[0], header[1])
+      headers.append(header[0], header[1])
     }
   } else if (typeof object === 'object' && object !== null) {
     // Note: null should throw
 
     // 2. Otherwise, object is a record, then for each key → value in object,
     //    append (key, value) to headers
-    const keys = Object.keys(object)
-    for (let i = 0; i < keys.length; ++i) {
-      appendHeader(headers, keys[i], object[keys[i]])
+    for (const [key, value] of Object.entries(object)) {
+      headers.append(key, value)
     }
   } else {
     throw webidl.errors.conversionFailed({
@@ -94227,50 +94449,6 @@ function fill (headers, object) {
   }
 }
 
-/**
- * @see https://fetch.spec.whatwg.org/#concept-headers-append
- */
-function appendHeader (headers, name, value) {
-  // 1. Normalize value.
-  value = headerValueNormalize(value)
-
-  // 2. If name is not a header name or value is not a
-  //    header value, then throw a TypeError.
-  if (!isValidHeaderName(name)) {
-    throw webidl.errors.invalidArgument({
-      prefix: 'Headers.append',
-      value: name,
-      type: 'header name'
-    })
-  } else if (!isValidHeaderValue(value)) {
-    throw webidl.errors.invalidArgument({
-      prefix: 'Headers.append',
-      value,
-      type: 'header value'
-    })
-  }
-
-  // 3. If headers’s guard is "immutable", then throw a TypeError.
-  // 4. Otherwise, if headers’s guard is "request" and name is a
-  //    forbidden header name, return.
-  // Note: undici does not implement forbidden header names
-  if (headers[kGuard] === 'immutable') {
-    throw new TypeError('immutable')
-  } else if (headers[kGuard] === 'request-no-cors') {
-    // 5. Otherwise, if headers’s guard is "request-no-cors":
-    // TODO
-  }
-
-  // 6. Otherwise, if headers’s guard is "response" and name is a
-  //    forbidden response-header name, return.
-
-  // 7. Append (name, value) to headers’s header list.
-  return headers[kHeadersList].append(name, value)
-
-  // 8. If headers’s guard is "request-no-cors", then remove
-  //    privileged no-CORS request headers from headers
-}
-
 class HeadersList {
   /** @type {[string, string][]|null} */
   cookies = null
@@ -94279,7 +94457,7 @@ class HeadersList {
     if (init instanceof HeadersList) {
       this[kHeadersMap] = new Map(init[kHeadersMap])
       this[kHeadersSortedMap] = init[kHeadersSortedMap]
-      this.cookies = init.cookies === null ? null : [...init.cookies]
+      this.cookies = init.cookies
     } else {
       this[kHeadersMap] = new Map(init)
       this[kHeadersSortedMap] = null
@@ -94341,7 +94519,7 @@ class HeadersList {
     //    the first such header to value and remove the
     //    others.
     // 2. Otherwise, append header (name, value) to list.
-    this[kHeadersMap].set(lowercaseName, { name, value })
+    return this[kHeadersMap].set(lowercaseName, { name, value })
   }
 
   // https://fetch.spec.whatwg.org/#concept-header-list-delete
@@ -94354,18 +94532,20 @@ class HeadersList {
       this.cookies = null
     }
 
-    this[kHeadersMap].delete(name)
+    return this[kHeadersMap].delete(name)
   }
 
   // https://fetch.spec.whatwg.org/#concept-header-list-get
   get (name) {
-    const value = this[kHeadersMap].get(name.toLowerCase())
-
     // 1. If list does not contain name, then return null.
+    if (!this.contains(name)) {
+      return null
+    }
+
     // 2. Return the values of all headers in list whose name
     //    is a byte-case-insensitive match for name,
     //    separated from each other by 0x2C 0x20, in order.
-    return value === undefined ? null : value.value
+    return this[kHeadersMap].get(name.toLowerCase())?.value ?? null
   }
 
   * [Symbol.iterator] () {
@@ -94391,9 +94571,6 @@ class HeadersList {
 // https://fetch.spec.whatwg.org/#headers-class
 class Headers {
   constructor (init = undefined) {
-    if (init === kConstruct) {
-      return
-    }
     this[kHeadersList] = new HeadersList()
 
     // The new Headers(init) constructor steps are:
@@ -94417,7 +94594,43 @@ class Headers {
     name = webidl.converters.ByteString(name)
     value = webidl.converters.ByteString(value)
 
-    return appendHeader(this, name, value)
+    // 1. Normalize value.
+    value = headerValueNormalize(value)
+
+    // 2. If name is not a header name or value is not a
+    //    header value, then throw a TypeError.
+    if (!isValidHeaderName(name)) {
+      throw webidl.errors.invalidArgument({
+        prefix: 'Headers.append',
+        value: name,
+        type: 'header name'
+      })
+    } else if (!isValidHeaderValue(value)) {
+      throw webidl.errors.invalidArgument({
+        prefix: 'Headers.append',
+        value,
+        type: 'header value'
+      })
+    }
+
+    // 3. If headers’s guard is "immutable", then throw a TypeError.
+    // 4. Otherwise, if headers’s guard is "request" and name is a
+    //    forbidden header name, return.
+    // Note: undici does not implement forbidden header names
+    if (this[kGuard] === 'immutable') {
+      throw new TypeError('immutable')
+    } else if (this[kGuard] === 'request-no-cors') {
+      // 5. Otherwise, if headers’s guard is "request-no-cors":
+      // TODO
+    }
+
+    // 6. Otherwise, if headers’s guard is "response" and name is a
+    //    forbidden response-header name, return.
+
+    // 7. Append (name, value) to headers’s header list.
+    // 8. If headers’s guard is "request-no-cors", then remove
+    //    privileged no-CORS request headers from headers
+    return this[kHeadersList].append(name, value)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-delete
@@ -94462,7 +94675,7 @@ class Headers {
     // 7. Delete name from this’s header list.
     // 8. If this’s guard is "request-no-cors", then remove
     //    privileged no-CORS request headers from this.
-    this[kHeadersList].delete(name)
+    return this[kHeadersList].delete(name)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-get
@@ -94555,7 +94768,7 @@ class Headers {
     // 7. Set (name, value) in this’s header list.
     // 8. If this’s guard is "request-no-cors", then remove
     //    privileged no-CORS request headers from this
-    this[kHeadersList].set(name, value)
+    return this[kHeadersList].set(name, value)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-getsetcookie
@@ -94591,8 +94804,7 @@ class Headers {
     const cookies = this[kHeadersList].cookies
 
     // 3. For each name of names:
-    for (let i = 0; i < names.length; ++i) {
-      const [name, value] = names[i]
+    for (const [name, value] of names) {
       // 1. If name is `set-cookie`, then:
       if (name === 'set-cookie') {
         // 1. Let values be a list of all values of headers in list whose name
@@ -94600,8 +94812,8 @@ class Headers {
 
         // 2. For each value of values:
         // 1. Append (name, value) to headers.
-        for (let j = 0; j < cookies.length; ++j) {
-          headers.push([name, cookies[j]])
+        for (const value of cookies) {
+          headers.push([name, value])
         }
       } else {
         // 2. Otherwise:
@@ -94625,12 +94837,6 @@ class Headers {
   keys () {
     webidl.brandCheck(this, Headers)
 
-    if (this[kGuard] === 'immutable') {
-      const value = this[kHeadersSortedMap]
-      return makeIterator(() => value, 'Headers',
-        'key')
-    }
-
     return makeIterator(
       () => [...this[kHeadersSortedMap].values()],
       'Headers',
@@ -94641,12 +94847,6 @@ class Headers {
   values () {
     webidl.brandCheck(this, Headers)
 
-    if (this[kGuard] === 'immutable') {
-      const value = this[kHeadersSortedMap]
-      return makeIterator(() => value, 'Headers',
-        'value')
-    }
-
     return makeIterator(
       () => [...this[kHeadersSortedMap].values()],
       'Headers',
@@ -94656,12 +94856,6 @@ class Headers {
 
   entries () {
     webidl.brandCheck(this, Headers)
-
-    if (this[kGuard] === 'immutable') {
-      const value = this[kHeadersSortedMap]
-      return makeIterator(() => value, 'Headers',
-        'key+value')
-    }
 
     return makeIterator(
       () => [...this[kHeadersSortedMap].values()],
@@ -95034,7 +95228,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
   }
 
   // 8. If response’s timing allow passed flag is not set, then:
-  if (!response.timingAllowPassed) {
+  if (!timingInfo.timingAllowPassed) {
     //  1. Set timingInfo to a the result of creating an opaque timing info for timingInfo.
     timingInfo = createOpaqueTimingInfo({
       startTime: timingInfo.startTime
@@ -96705,7 +96899,7 @@ async function httpNetworkFetch (
         path: url.pathname + url.search,
         origin: url.origin,
         method: request.method,
-        body: fetchParams.controller.dispatcher.isMockActive ? request.body && (request.body.source || request.body.stream) : body,
+        body: fetchParams.controller.dispatcher.isMockActive ? request.body && request.body.source : body,
         headers: request.headersList.entries,
         maxRedirections: 0,
         upgrade: request.mode === 'websocket' ? 'websocket' : undefined
@@ -96750,7 +96944,7 @@ async function httpNetworkFetch (
                 location = val
               }
 
-              headers[kHeadersList].append(key, val)
+              headers.append(key, val)
             }
           } else {
             const keys = Object.keys(headersList)
@@ -96764,7 +96958,7 @@ async function httpNetworkFetch (
                 location = val
               }
 
-              headers[kHeadersList].append(key, val)
+              headers.append(key, val)
             }
           }
 
@@ -96868,7 +97062,7 @@ async function httpNetworkFetch (
             const key = headersList[n + 0].toString('latin1')
             const val = headersList[n + 1].toString('latin1')
 
-            headers[kHeadersList].append(key, val)
+            headers.append(key, val)
           }
 
           resolve({
@@ -96911,8 +97105,7 @@ const {
   isValidHTTPToken,
   sameOrigin,
   normalizeMethod,
-  makePolicyContainer,
-  normalizeMethodRecord
+  makePolicyContainer
 } = __nccwpck_require__(52538)
 const {
   forbiddenMethodsSet,
@@ -96929,12 +97122,13 @@ const { kHeaders, kSignal, kState, kGuard, kRealm } = __nccwpck_require__(15861)
 const { webidl } = __nccwpck_require__(21744)
 const { getGlobalOrigin } = __nccwpck_require__(71246)
 const { URLSerializer } = __nccwpck_require__(685)
-const { kHeadersList, kConstruct } = __nccwpck_require__(72785)
+const { kHeadersList } = __nccwpck_require__(72785)
 const assert = __nccwpck_require__(39491)
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __nccwpck_require__(82361)
 
 let TransformStream = globalThis.TransformStream
 
+const kInit = Symbol('init')
 const kAbortController = Symbol('abortController')
 
 const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
@@ -96945,7 +97139,7 @@ const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
 class Request {
   // https://fetch.spec.whatwg.org/#dom-request
   constructor (input, init = {}) {
-    if (input === kConstruct) {
+    if (input === kInit) {
       return
     }
 
@@ -97084,10 +97278,8 @@ class Request {
       urlList: [...request.urlList]
     })
 
-    const initHasKey = Object.keys(init).length !== 0
-
     // 13. If init is not empty, then:
-    if (initHasKey) {
+    if (Object.keys(init).length > 0) {
       // 1. If request’s mode is "navigate", then set it to "same-origin".
       if (request.mode === 'navigate') {
         request.mode = 'same-origin'
@@ -97202,7 +97394,7 @@ class Request {
     }
 
     // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
-    if (init.integrity != null) {
+    if (init.integrity !== undefined && init.integrity != null) {
       request.integrity = String(init.integrity)
     }
 
@@ -97218,16 +97410,16 @@ class Request {
 
       // 2. If method is not a method or method is a forbidden method, then
       // throw a TypeError.
-      if (!isValidHTTPToken(method)) {
-        throw new TypeError(`'${method}' is not a valid HTTP method.`)
+      if (!isValidHTTPToken(init.method)) {
+        throw TypeError(`'${init.method}' is not a valid HTTP method.`)
       }
 
       if (forbiddenMethodsSet.has(method.toUpperCase())) {
-        throw new TypeError(`'${method}' HTTP method is unsupported.`)
+        throw TypeError(`'${init.method}' HTTP method is unsupported.`)
       }
 
       // 3. Normalize method.
-      method = normalizeMethodRecord[method] ?? normalizeMethod(method)
+      method = normalizeMethod(init.method)
 
       // 4. Set request’s method to method.
       request.method = method
@@ -97298,7 +97490,7 @@ class Request {
     // 30. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is request’s header list and guard is
     // "request".
-    this[kHeaders] = new Headers(kConstruct)
+    this[kHeaders] = new Headers()
     this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kGuard] = 'request'
     this[kHeaders][kRealm] = this[kRealm]
@@ -97318,25 +97510,25 @@ class Request {
     }
 
     // 32. If init is not empty, then:
-    if (initHasKey) {
-      /** @type {HeadersList} */
-      const headersList = this[kHeaders][kHeadersList]
+    if (Object.keys(init).length !== 0) {
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
+      let headers = new Headers(this[kHeaders])
+
       // 2. If init["headers"] exists, then set headers to init["headers"].
-      const headers = init.headers !== undefined ? init.headers : new HeadersList(headersList)
+      if (init.headers !== undefined) {
+        headers = init.headers
+      }
 
       // 3. Empty this’s headers’s header list.
-      headersList.clear()
+      this[kHeaders][kHeadersList].clear()
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
-      if (headers instanceof HeadersList) {
+      if (headers.constructor.name === 'Headers') {
         for (const [key, val] of headers) {
-          headersList.append(key, val)
+          this[kHeaders].append(key, val)
         }
-        // Note: Copy the `set-cookie` meta-data.
-        headersList.cookies = headers.cookies
       } else {
         // 5. Otherwise, fill this’s headers with headers.
         fillHeaders(this[kHeaders], headers)
@@ -97625,10 +97817,10 @@ class Request {
 
     // 3. Let clonedRequestObject be the result of creating a Request object,
     // given clonedRequest, this’s headers’s guard, and this’s relevant Realm.
-    const clonedRequestObject = new Request(kConstruct)
+    const clonedRequestObject = new Request(kInit)
     clonedRequestObject[kState] = clonedRequest
     clonedRequestObject[kRealm] = this[kRealm]
-    clonedRequestObject[kHeaders] = new Headers(kConstruct)
+    clonedRequestObject[kHeaders] = new Headers()
     clonedRequestObject[kHeaders][kHeadersList] = clonedRequest.headersList
     clonedRequestObject[kHeaders][kGuard] = this[kHeaders][kGuard]
     clonedRequestObject[kHeaders][kRealm] = this[kHeaders][kRealm]
@@ -97878,7 +98070,7 @@ const { webidl } = __nccwpck_require__(21744)
 const { FormData } = __nccwpck_require__(72015)
 const { getGlobalOrigin } = __nccwpck_require__(71246)
 const { URLSerializer } = __nccwpck_require__(685)
-const { kHeadersList, kConstruct } = __nccwpck_require__(72785)
+const { kHeadersList } = __nccwpck_require__(72785)
 const assert = __nccwpck_require__(39491)
 const { types } = __nccwpck_require__(73837)
 
@@ -97999,7 +98191,7 @@ class Response {
     // 2. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is this’s response’s header list and guard
     // is "response".
-    this[kHeaders] = new Headers(kConstruct)
+    this[kHeaders] = new Headers()
     this[kHeaders][kGuard] = 'response'
     this[kHeaders][kHeadersList] = this[kState].headersList
     this[kHeaders][kRealm] = this[kRealm]
@@ -98369,7 +98561,11 @@ webidl.converters.XMLHttpRequestBodyInit = function (V) {
     return webidl.converters.Blob(V, { strict: false })
   }
 
-  if (types.isArrayBuffer(V) || types.isTypedArray(V) || types.isDataView(V)) {
+  if (
+    types.isAnyArrayBuffer(V) ||
+    types.isTypedArray(V) ||
+    types.isDataView(V)
+  ) {
     return webidl.converters.BufferSource(V)
   }
 
@@ -98555,57 +98751,52 @@ function isValidReasonPhrase (statusText) {
   return true
 }
 
-/**
- * @see https://tools.ietf.org/html/rfc7230#section-3.2.6
- * @param {number} c
- */
-function isTokenCharCode (c) {
-  switch (c) {
-    case 0x22:
-    case 0x28:
-    case 0x29:
-    case 0x2c:
-    case 0x2f:
-    case 0x3a:
-    case 0x3b:
-    case 0x3c:
-    case 0x3d:
-    case 0x3e:
-    case 0x3f:
-    case 0x40:
-    case 0x5b:
-    case 0x5c:
-    case 0x5d:
-    case 0x7b:
-    case 0x7d:
-      // DQUOTE and "(),/:;<=>?@[\]{}"
-      return false
-    default:
-      // VCHAR %x21-7E
-      return c >= 0x21 && c <= 0x7e
-  }
+function isTokenChar (c) {
+  return !(
+    c >= 0x7f ||
+    c <= 0x20 ||
+    c === '(' ||
+    c === ')' ||
+    c === '<' ||
+    c === '>' ||
+    c === '@' ||
+    c === ',' ||
+    c === ';' ||
+    c === ':' ||
+    c === '\\' ||
+    c === '"' ||
+    c === '/' ||
+    c === '[' ||
+    c === ']' ||
+    c === '?' ||
+    c === '=' ||
+    c === '{' ||
+    c === '}'
+  )
 }
 
-/**
- * @param {string} characters
- */
+// See RFC 7230, Section 3.2.6.
+// https://github.com/chromium/chromium/blob/d7da0240cae77824d1eda25745c4022757499131/third_party/blink/renderer/platform/network/http_parsers.cc#L321
 function isValidHTTPToken (characters) {
-  if (characters.length === 0) {
+  if (!characters || typeof characters !== 'string') {
     return false
   }
   for (let i = 0; i < characters.length; ++i) {
-    if (!isTokenCharCode(characters.charCodeAt(i))) {
+    const c = characters.charCodeAt(i)
+    if (c > 0x7f || !isTokenChar(c)) {
       return false
     }
   }
   return true
 }
 
-/**
- * @see https://fetch.spec.whatwg.org/#header-name
- * @param {string} potentialValue
- */
+// https://fetch.spec.whatwg.org/#header-name
+// https://github.com/chromium/chromium/blob/b3d37e6f94f87d59e44662d6078f6a12de845d17/net/http/http_util.cc#L342
 function isValidHeaderName (potentialValue) {
+  if (potentialValue.length === 0) {
+    return false
+  }
+
   return isValidHTTPToken(potentialValue)
 }
 
@@ -99150,30 +99341,11 @@ function isCancelled (fetchParams) {
     fetchParams.controller.state === 'terminated'
 }
 
-const normalizeMethodRecord = {
-  delete: 'DELETE',
-  DELETE: 'DELETE',
-  get: 'GET',
-  GET: 'GET',
-  head: 'HEAD',
-  HEAD: 'HEAD',
-  options: 'OPTIONS',
-  OPTIONS: 'OPTIONS',
-  post: 'POST',
-  POST: 'POST',
-  put: 'PUT',
-  PUT: 'PUT'
-}
-
-// Note: object prototypes should not be able to be referenced. e.g. `Object#hasOwnProperty`.
-Object.setPrototypeOf(normalizeMethodRecord, null)
-
-/**
- * @see https://fetch.spec.whatwg.org/#concept-method-normalize
- * @param {string} method
- */
+// https://fetch.spec.whatwg.org/#concept-method-normalize
 function normalizeMethod (method) {
-  return normalizeMethodRecord[method.toLowerCase()] ?? method
+  return /^(DELETE|GET|HEAD|OPTIONS|POST|PUT)$/i.test(method)
+    ? method.toUpperCase()
+    : method
 }
 
 // https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-a-json-string
@@ -99518,8 +99690,7 @@ module.exports = {
   urlIsLocal,
   urlHasHttpsScheme,
   urlIsHttpHttpsScheme,
-  readAllBytes,
-  normalizeMethodRecord
+  readAllBytes
 }
 
 
@@ -99958,10 +100129,12 @@ webidl.converters.ByteString = function (V) {
   // 2. If the value of any element of x is greater than
   //    255, then throw a TypeError.
   for (let index = 0; index < x.length; index++) {
-    if (x.charCodeAt(index) > 255) {
+    const charCode = x.charCodeAt(index)
+
+    if (charCode > 255) {
       throw new TypeError(
         'Cannot convert argument to a ByteString because the character at ' +
-        `index ${index} has a value of ${x.charCodeAt(index)} which is greater than 255.`
+        `index ${index} has a value of ${charCode} which is greater than 255.`
       )
     }
   }
@@ -101636,349 +101809,6 @@ function cleanRequestHeaders (headers, removeContent, unknownOrigin) {
 }
 
 module.exports = RedirectHandler
-
-
-/***/ }),
-
-/***/ 82286:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-const assert = __nccwpck_require__(39491)
-
-const { kRetryHandlerDefaultRetry } = __nccwpck_require__(72785)
-const { RequestRetryError } = __nccwpck_require__(48045)
-const { isDisturbed, parseHeaders, parseRangeHeader } = __nccwpck_require__(83983)
-
-function calculateRetryAfterHeader (retryAfter) {
-  const current = Date.now()
-  const diff = new Date(retryAfter).getTime() - current
-
-  return diff
-}
-
-class RetryHandler {
-  constructor (opts, handlers) {
-    const { retryOptions, ...dispatchOpts } = opts
-    const {
-      // Retry scoped
-      retry: retryFn,
-      maxRetries,
-      maxTimeout,
-      minTimeout,
-      timeoutFactor,
-      // Response scoped
-      methods,
-      errorCodes,
-      retryAfter,
-      statusCodes
-    } = retryOptions ?? {}
-
-    this.dispatch = handlers.dispatch
-    this.handler = handlers.handler
-    this.opts = dispatchOpts
-    this.abort = null
-    this.aborted = false
-    this.retryOpts = {
-      retry: retryFn ?? RetryHandler[kRetryHandlerDefaultRetry],
-      retryAfter: retryAfter ?? true,
-      maxTimeout: maxTimeout ?? 30 * 1000, // 30s,
-      timeout: minTimeout ?? 500, // .5s
-      timeoutFactor: timeoutFactor ?? 2,
-      maxRetries: maxRetries ?? 5,
-      // What errors we should retry
-      methods: methods ?? ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE', 'TRACE'],
-      // Indicates which errors to retry
-      statusCodes: statusCodes ?? [500, 502, 503, 504, 429],
-      // List of errors to retry
-      errorCodes: errorCodes ?? [
-        'ECONNRESET',
-        'ECONNREFUSED',
-        'ENOTFOUND',
-        'ENETDOWN',
-        'ENETUNREACH',
-        'EHOSTDOWN',
-        'EHOSTUNREACH',
-        'EPIPE'
-      ]
-    }
-
-    this.retryCount = 0
-    this.start = 0
-    this.end = null
-    this.etag = null
-    this.resume = null
-
-    // Handle possible onConnect duplication
-    this.handler.onConnect(reason => {
-      this.aborted = true
-      if (this.abort) {
-        this.abort(reason)
-      } else {
-        this.reason = reason
-      }
-    })
-  }
-
-  onRequestSent () {
-    if (this.handler.onRequestSent) {
-      this.handler.onRequestSent()
-    }
-  }
-
-  onUpgrade (statusCode, headers, socket) {
-    if (this.handler.onUpgrade) {
-      this.handler.onUpgrade(statusCode, headers, socket)
-    }
-  }
-
-  onConnect (abort) {
-    if (this.aborted) {
-      abort(this.reason)
-    } else {
-      this.abort = abort
-    }
-  }
-
-  onBodySent (chunk) {
-    if (this.handler.onBodySent) return this.handler.onBodySent(chunk)
-  }
-
-  static [kRetryHandlerDefaultRetry] (err, { state, opts }, cb) {
-    const { statusCode, code, headers } = err
-    const { method, retryOptions } = opts
-    const {
-      maxRetries,
-      timeout,
-      maxTimeout,
-      timeoutFactor,
-      statusCodes,
-      errorCodes,
-      methods
-    } = retryOptions
-    let { counter, currentTimeout } = state
-
-    currentTimeout =
-      currentTimeout != null && currentTimeout > 0 ? currentTimeout : timeout
-
-    // Any code that is not a Undici's originated and allowed to retry
-    if (
-      code &&
-      code !== 'UND_ERR_REQ_RETRY' &&
-      code !== 'UND_ERR_SOCKET' &&
-      !errorCodes.includes(code)
-    ) {
-      cb(err)
-      return
-    }
-
-    // If a set of method are provided and the current method is not in the list
-    if (Array.isArray(methods) && !methods.includes(method)) {
-      cb(err)
-      return
-    }
-
-    // If a set of status code are provided and the current status code is not in the list
-    if (
-      statusCode != null &&
-      Array.isArray(statusCodes) &&
-      !statusCodes.includes(statusCode)
-    ) {
-      cb(err)
-      return
-    }
-
-    // If we reached the max number of retries
-    if (counter > maxRetries) {
-      cb(err)
-      return
-    }
-
-    let retryAfterHeader = headers != null && headers['retry-after']
-    if (retryAfterHeader) {
-      retryAfterHeader = Number(retryAfterHeader)
-      retryAfterHeader = isNaN(retryAfterHeader)
-        ? calculateRetryAfterHeader(retryAfterHeader)
-        : retryAfterHeader * 1e3 // Retry-After is in seconds
-    }
-
-    const retryTimeout =
-      retryAfterHeader > 0
-        ? Math.min(retryAfterHeader, maxTimeout)
-        : Math.min(currentTimeout * timeoutFactor ** counter, maxTimeout)
-
-    state.currentTimeout = retryTimeout
-
-    setTimeout(() => cb(null), retryTimeout)
-  }
-
-  onHeaders (statusCode, rawHeaders, resume, statusMessage) {
-    const headers = parseHeaders(rawHeaders)
-
-    this.retryCount += 1
-
-    if (statusCode >= 300) {
-      this.abort(
-        new RequestRetryError('Request failed', statusCode, {
-          headers,
-          count: this.retryCount
-        })
-      )
-      return false
-    }
-
-    // Checkpoint for resume from where we left it
-    if (this.resume != null) {
-      this.resume = null
-
-      if (statusCode !== 206) {
-        return true
-      }
-
-      const contentRange = parseRangeHeader(headers['content-range'])
-      // If no content range
-      if (!contentRange) {
-        this.abort(
-          new RequestRetryError('Content-Range mismatch', statusCode, {
-            headers,
-            count: this.retryCount
-          })
-        )
-        return false
-      }
-
-      // Let's start with a weak etag check
-      if (this.etag != null && this.etag !== headers.etag) {
-        this.abort(
-          new RequestRetryError('ETag mismatch', statusCode, {
-            headers,
-            count: this.retryCount
-          })
-        )
-        return false
-      }
-
-      const { start, size, end = size } = contentRange
-
-      assert(this.start === start, 'content-range mismatch')
-      assert(this.end == null || this.end === end, 'content-range mismatch')
-
-      this.resume = resume
-      return true
-    }
-
-    if (this.end == null) {
-      if (statusCode === 206) {
-        // First time we receive 206
-        const range = parseRangeHeader(headers['content-range'])
-
-        if (range == null) {
-          return this.handler.onHeaders(
-            statusCode,
-            rawHeaders,
-            resume,
-            statusMessage
-          )
-        }
-
-        const { start, size, end = size } = range
-
-        assert(
-          start != null && Number.isFinite(start) && this.start !== start,
-          'content-range mismatch'
-        )
-        assert(Number.isFinite(start))
-        assert(
-          end != null && Number.isFinite(end) && this.end !== end,
-          'invalid content-length'
-        )
-
-        this.start = start
-        this.end = end
-      }
-
-      // We make our best to checkpoint the body for further range headers
-      if (this.end == null) {
-        const contentLength = headers['content-length']
-        this.end = contentLength != null ? Number(contentLength) : null
-      }
-
-      assert(Number.isFinite(this.start))
-      assert(
-        this.end == null || Number.isFinite(this.end),
-        'invalid content-length'
-      )
-
-      this.resume = resume
-      this.etag = headers.etag != null ? headers.etag : null
-
-      return this.handler.onHeaders(
-        statusCode,
-        rawHeaders,
-        resume,
-        statusMessage
-      )
-    }
-
-    const err = new RequestRetryError('Request failed', statusCode, {
-      headers,
-      count: this.retryCount
-    })
-
-    this.abort(err)
-
-    return false
-  }
-
-  onData (chunk) {
-    this.start += chunk.length
-
-    return this.handler.onData(chunk)
-  }
-
-  onComplete (rawTrailers) {
-    this.retryCount = 0
-    return this.handler.onComplete(rawTrailers)
-  }
-
-  onError (err) {
-    if (this.aborted || isDisturbed(this.opts.body)) {
-      return this.handler.onError(err)
-    }
-
-    this.retryOpts.retry(
-      err,
-      {
-        state: { counter: this.retryCount++, currentTimeout: this.retryAfter },
-        opts: { retryOptions: this.retryOpts, ...this.opts }
-      },
-      onRetry.bind(this)
-    )
-
-    function onRetry (err) {
-      if (err != null || this.aborted || isDisturbed(this.opts.body)) {
-        return this.handler.onError(err)
-      }
-
-      if (this.start !== 0) {
-        this.opts = {
-          ...this.opts,
-          headers: {
-            ...this.opts.headers,
-            range: `bytes=${this.start}-${this.end ?? ''}`
-          }
-        }
-      }
-
-      try {
-        this.dispatch(this.opts, this)
-      } catch (err) {
-        this.handler.onError(err)
-      }
-    }
-  }
-}
-
-module.exports = RetryHandler
 
 
 /***/ }),
@@ -103903,9 +103733,6 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = opts.headers || {}
 
-    const resolvedUrl = new URL(opts.uri)
-    const { origin, port, host, username, password } = resolvedUrl
-
     if (opts.auth && opts.token) {
       throw new InvalidArgumentError('opts.auth cannot be used in combination with opts.token')
     } else if (opts.auth) {
@@ -103913,9 +103740,10 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
     } else if (opts.token) {
       this[kProxyHeaders]['proxy-authorization'] = opts.token
-    } else if (username && password) {
-      this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
     }
+
+    const resolvedUrl = new URL(opts.uri)
+    const { origin, port, host } = resolvedUrl
 
     const connect = buildConnector({ ...opts.proxyTls })
     this[kConnectEndpoint] = buildConnector({ ...opts.requestTls })
@@ -103940,7 +103768,7 @@ class ProxyAgent extends DispatcherBase {
           })
           if (statusCode !== 200) {
             socket.on('error', () => {}).destroy()
-            callback(new RequestAbortedError(`Proxy response (${statusCode}) !== 200 when HTTP Tunneling`))
+            callback(new RequestAbortedError('Proxy response !== 200 when HTTP Tunneling'))
           }
           if (opts.protocol !== 'https:') {
             callback(null, socket)
@@ -114762,6 +114590,7 @@ governing permissions and limitations under the License.
 */
 
 const Ajv = __nccwpck_require__(72426)
+const AjvErrors = __nccwpck_require__(50424)
 
 /**
  * Validates json according to a schema.
@@ -114773,6 +114602,7 @@ const Ajv = __nccwpck_require__(72426)
  */
 function validate (schema, data) {
   const ajv = new Ajv({ allErrors: true })
+  AjvErrors(ajv)
   const validate = ajv.compile(schema)
   const valid = validate(data)
 
@@ -114815,7 +114645,13 @@ async function generateOAuthSTSAuthToken (params = {}) {
   const schema = {
     type: 'object',
     properties: {
-      scopes: { type: 'string' },
+      scopes: {
+        type: 'string',
+        // The escaped \s is needed to allow spaces
+        // eslint-disable-next-line no-useless-escape
+        pattern: '^[0-9a-zA-Z_.\s]+(,[0-9a-zA-Z_.\s]+)*', // Example: scope1, scope2, scope3. or scope1,scope2,scope3.
+        errorMessage: 'Invalid scopes format. Must be a comma separated list of scopes (e.g. scope1, scope2, scope3 or scope1,scope2,scope3)'
+      },
       clientId: { type: 'string' },
       clientSecret: { type: 'string' },
       techAccId: { type: 'string' },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "GitHub Action to Build, Test and Deploy AIO Apps",
   "scripts": {
-    "lint": "eslint src test",
+    "lint": "eslint src test --fix",
     "test": "npm run unit-tests && npm run lint && npm run package",
     "unit-tests": "jest -c jest.config.js",
     "package": "ncc build src/index.js -o dist/"
@@ -12,7 +12,8 @@
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@adobe/aio-lib-ims": "7.0.0",
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "ajv-errors": "^3.0.0"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "GitHub Action to Build, Test and Deploy AIO Apps",
   "scripts": {
-    "lint": "eslint src test --fix",
+    "lint": "eslint src test",
     "test": "npm run unit-tests && npm run lint && npm run package",
     "unit-tests": "jest -c jest.config.js",
     "package": "ncc build src/index.js -o dist/"

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const Ajv = require('ajv')
+const AjvErrors = require('ajv-errors')
 
 /**
  * Validates json according to a schema.
@@ -22,6 +23,7 @@ const Ajv = require('ajv')
  */
 function validate (schema, data) {
   const ajv = new Ajv({ allErrors: true })
+  AjvErrors(ajv)
   const validate = ajv.compile(schema)
   const valid = validate(data)
 
@@ -64,7 +66,13 @@ async function generateOAuthSTSAuthToken (params = {}) {
   const schema = {
     type: 'object',
     properties: {
-      scopes: { type: 'string' },
+      scopes: {
+        type: 'string',
+        // The escaped \s is needed to allow spaces
+        // eslint-disable-next-line no-useless-escape
+        pattern: '^[0-9a-zA-Z_.\s]+(,[0-9a-zA-Z_.\s]+)*', // Example: scope1, scope2, scope3. or scope1,scope2,scope3.
+        errorMessage: 'Invalid scopes format. Must be a comma separated list of scopes (e.g. scope1, scope2, scope3 or scope1,scope2,scope3)'
+      },
       clientId: { type: 'string' },
       clientSecret: { type: 'string' },
       techAccId: { type: 'string' },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -198,7 +198,21 @@ describe('generateOAuthSTSAuthToken', () => {
     await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
   })
 
-  test('all required inputs available', async () => {
+  test('invalid scope format', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id',
+      scopes: '[scope1, scope2]'
+    }
+    await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
+  })
+
+  test('invalid scope format, deprecated jwt', async () => {
     const inputs = {
       ims,
       key: 'key',
@@ -208,6 +222,52 @@ describe('generateOAuthSTSAuthToken', () => {
       techAccEmail: 'tech-acct-email',
       imsOrgId: 'ims-org-id',
       scopes: '["ent_adobeio_sdk"]'
+    }
+    await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
+  })
+
+  test('all required inputs available, no spaces between scopes', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id',
+      scopes: 'scope1,scope2'
+    }
+    const token = 'my-token'
+    ims.getToken.mockResolvedValue(token)
+    await expect(generateOAuthSTSAuthToken(inputs)).resolves.toEqual(token)
+  })
+
+  test('all required inputs available, additional accepted chars in scopes', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id',
+      scopes: 'scope_1, scope2.projectedContext'
+    }
+    const token = 'my-token'
+    ims.getToken.mockResolvedValue(token)
+    await expect(generateOAuthSTSAuthToken(inputs)).resolves.toEqual(token)
+  })
+
+  test('all required inputs available', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id',
+      scopes: 'scope1, scope2'
     }
     const token = 'my-token'
     ims.getToken.mockResolvedValue(token)


### PR DESCRIPTION
## Description

Use a regex to validate the oauth scopes format (comma-separated list with no quotes/double-quotes)

(Note: scope validation is already supported with the deprecated jwt step, this is bringing oauth up to par with that)

## Related Issue

[ACNA-2762](https://jira.corp.adobe.com/browse/ACNA-2762)

## Motivation and Context

## How Has This Been Tested?

`npm run test`

[Real valid scope format run
](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7730126502/job/21074825348#step:6:16)

[Real invalid scope format run](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7730151666/job/21074917247#step:6:32)

[Real invalid scope format run, specifically using the deprecated jwt format](https://github.com/MichaelGoberling/app-builder-gh-action/actions/runs/7729971106/job/21074731283#step:6:32)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
