### PR TITLE
fix: validation errors when no scopes configured

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ async function main () {
   const command = core.getInput('command')
   const noPublish = core.getInput('noPublish')
   const key = core.getInput('key')
-  const scopes = core.getInput('scopes')
+  const scopes = core.getInput('scopes') || undefined
   const clientId = core.getInput('clientId')
   const clientSecret = core.getInput('clientSecret')
   const techAccId = core.getInput('technicalAccountId')

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -198,6 +198,20 @@ describe('generateOAuthSTSAuthToken', () => {
     await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
   })
 
+  test('scopes is an empty string', async () => {
+    const inputs = {
+      ims,
+      key: 'key',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      techAccId: 'tech-acct-id',
+      techAccEmail: 'tech-acct-email',
+      imsOrgId: 'ims-org-id',
+      scopes: ''
+    }
+    await expect(generateOAuthSTSAuthToken(inputs)).rejects.toThrow('[generateOAuthSTSAuthToken] Validation errors:')
+  })
+
   test('use default scopes', async () => {
     const inputs = {
       ims,


### PR DESCRIPTION
Users with no scopes configured were getting validation errors: 
```
Error: [generateOAuthSTSAuthToken] Validation errors: [
  {
    ...,
    "message": "Invalid scopes format. Must be a comma separated list of scopes (e.g. scope1, scope2, scope3 or scope1,scope2,scope3)"
  }
]
```

This case should actually result in the action using the default scopes (from I/O Management API), however `core.getInput()` returns an empty string for un-configured inputs, which was failing validation. We can just make scopes undefined so it gets ignored during validation
